### PR TITLE
Disable XML External Entities

### DIFF
--- a/mydoggy-plaf/src/main/java/org/noos/xing/mydoggy/plaf/persistence/xml/XMLPersistenceDelegate.java
+++ b/mydoggy-plaf/src/main/java/org/noos/xing/mydoggy/plaf/persistence/xml/XMLPersistenceDelegate.java
@@ -167,6 +167,9 @@ public class XMLPersistenceDelegate implements PersistenceDelegate {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(inputStream);
 


### PR DESCRIPTION
External Entity Processing allows for XML parsing with the involvement of external entities. However, when this functionality is enabled without proper precautions, it can lead to a vulnerability known as XML External Entity (XXE) attack.