### PR TITLE
Do not update the select tab from TabbedContentPane

### DIFF
--- a/mydoggy-plaf/src/main/java/org/noos/xing/mydoggy/plaf/ui/cmp/TabbedContentPane.java
+++ b/mydoggy-plaf/src/main/java/org/noos/xing/mydoggy/plaf/ui/cmp/TabbedContentPane.java
@@ -587,16 +587,6 @@ public class TabbedContentPane extends JTabbedPane implements PropertyChangeList
                 selectionOnPressed = (aggregateIcon.getIndex() == mouseOverTab);
             }
             mouseOverTabWhenPressed = mouseOverTab;
-
-            if (mouseOverTab != -1) {
-                Content newSelected = getContentAt(mouseOverTab);
-                if (newSelected != null && !newSelected.isMaximized()) {
-                    Content oldSelected = toolWindowManager.getContentManager().getSelectedContent();
-                    if (newSelected != oldSelected) {
-                        newSelected.setSelected(true);
-                    }
-                }
-            }
         }
 
         public void mouseClicked(MouseEvent e) {


### PR DESCRIPTION
When tabs are spread on multiple rows and when a tab is clicked, some tabs dimensions will change (adding/removing the detach/close buttons) therefore the position of the clicked tab might change. In that case updating the selection from TabbedContentPane interfers with Swing's native calculation of the clicked tab, because the X/Y coordinates now correspond to another tab.
In the end the user clicked a tab and another was selected.